### PR TITLE
Help messages

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -24,6 +24,7 @@ Library
     Build-Depends:
         base                 >= 4.6     && < 5   ,
         system-filepath      >= 0.3.1   && < 0.5 ,
+        tagged               >= 0.8.3   && < 0.9 ,
         text                               < 1.3 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
         optparse-applicative >= 0.11.0  && < 0.13,

--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -24,10 +24,13 @@ Library
     Build-Depends:
         base                 >= 4.6     && < 5   ,
         system-filepath      >= 0.3.1   && < 0.5 ,
-        tagged               >= 0.8.3   && < 0.9 ,
         text                               < 1.3 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
         optparse-applicative >= 0.11.0  && < 0.13,
         void                               < 0.8
+    if impl(ghc < 7.8)
+        Build-Depends:
+            singletons       >= 2.0.1   && < 2.1 ,
+            tagged           >= 0.8.3   && < 0.9
     Exposed-Modules: Options.Generic
     GHC-Options: -Wall

--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -30,7 +30,7 @@ Library
         void                               < 0.8
     if impl(ghc < 7.8)
         Build-Depends:
-            singletons       >= 2.0.1   && < 2.1 ,
+            singletons       >= 0.10.0  && < 1.0 ,
             tagged           >= 0.8.3   && < 0.9
     Exposed-Modules: Options.Generic
     GHC-Options: -Wall

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -415,7 +415,6 @@ instance Show field => Show (field <?> help) where show = show . unHelpful
 instance (ParseField a, KnownSymbol h) => ParseField (a <?> h) where
     parseHelpfulField _ m = Helpful <$> parseHelpfulField (Just (symbolVal (Proxy :: Proxy h))) m
 
---instance (ParseField a, ParseFields a, KnownSymbol h) => ParseFields (a <?> h)
 instance (ParseFields a, KnownSymbol h) => ParseFields (a <?> h) where
     parseHelpfulFields _ m = Helpful <$> parseHelpfulFields (Just (symbolVal (Proxy :: Proxy h))) m
 instance (ParseFields a, KnownSymbol h) => ParseRecord (a <?> h)

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -232,15 +232,16 @@ auto = do
     language extension
 -}
 class ParseField a where
-        --(forall f b. Options.Mod f b)
     parseHelpfulField
         :: Maybe String
+        -- ^ Help message
         -> Maybe Text
         -- ^ Field label
         -> Parser a
     default parseHelpfulField
         :: (Typeable a, Read a)
         => Maybe String
+        -- ^ Help message
         -> Maybe Text
         -- ^ Field label
         -> Parser a
@@ -268,6 +269,7 @@ class ParseField a where
     -}
     parseListOfHelpfulField
         :: Maybe String
+        -- ^ Help message
         -> Maybe Text
         -- ^ Field label
         -> Parser [a]
@@ -348,6 +350,7 @@ instance ParseField FilePath where
 class ParseRecord a => ParseFields a where
     parseHelpfulFields
         :: Maybe String
+        -- ^ Help message
         -> Maybe Text
         -- ^ Field label
         -> Parser a

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeOperators              #-}
 
 -- | This library auto-generates command-line parsers for data types using
 -- Haskell's built-in support for generic programming.  The best way to

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeOperators              #-}
 

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveGeneric              #-}
@@ -198,7 +199,6 @@ import Data.Typeable (Typeable)
 import Data.Void (Void)
 import Filesystem.Path (FilePath)
 import GHC.Generics
-import GHC.TypeLits
 import Prelude hiding (FilePath)
 import Options.Applicative (Parser, ReadM)
 
@@ -209,6 +209,12 @@ import qualified Filesystem.Path.CurrentOS as Filesystem
 import qualified Options.Applicative       as Options
 import qualified Options.Applicative.Types as Options
 import qualified Text.Read
+
+#if MIN_VERSION_base(4,7,0)
+import GHC.TypeLits
+#else
+import Data.Singletons.TypeLits
+#endif
 
 auto :: Read a => ReadM a
 auto = do

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -360,7 +360,7 @@ class ParseRecord a => ParseFields a where
         :: Maybe Text
         -- ^ Field label
         -> Parser a
-    parseFields = parseHelpfulFields mempty
+    parseFields = parseHelpfulFields Nothing
 
 instance ParseFields Char
 instance ParseFields Double


### PR DESCRIPTION
Add help messages using type level strings.
- I tried to make this modular in somewhat the same sense as the using `parseListOfField` is used to propagate list parsing correctly, I added `parseFieldH` and `parseFieldsH` to propagate help messages. I don't know if this is the best solution vs a bunch of duplicated instance declarations.
- I'd be interested to see how to extend this to short options. Haskell doesn't have type level characters unfortunately, so either use a tagged type level string operator `<->` or extend the `<?>` operator so that a user can add a short option to it like "-s help message".
- I haven't tested it a lot ;-)
