### PR TITLE
Add ParseField instance for Data.ByteString.Char8

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -28,6 +28,7 @@ Library
         transformers         >= 0.2.0.0 && < 0.6 ,
         optparse-applicative >= 0.11.0  && < 0.13,
         time                 >= 1.5     && < 1.7,
-        void                               < 0.8
+        void                               < 0.8,
+        bytestring                         < 0.11
     Exposed-Modules: Options.Generic
     GHC-Options: -Wall

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -197,10 +197,12 @@ import Options.Applicative (Parser, ReadM)
 import qualified Data.Text
 import qualified Data.Text.Encoding
 import qualified Data.Text.Lazy
+import qualified Data.Text.Lazy.Encoding
 import qualified Data.Time.Calendar
 import qualified Data.Time.Format
 import qualified Data.Typeable
 import qualified Data.ByteString
+import qualified Data.ByteString.Lazy
 import qualified Filesystem.Path.CurrentOS as Filesystem
 import qualified Options.Applicative       as Options
 import qualified Options.Applicative.Types as Options
@@ -304,8 +306,14 @@ instance ParseField Data.Text.Text where
 instance ParseField Data.ByteString.ByteString where
     parseField = fmap (fmap (Data.Text.Encoding.encodeUtf8)) (parseText "UTF8-BYTESTRING")
 
+parseTextLazy :: String -> Maybe Text -> Parser Data.Text.Lazy.Text
+parseTextLazy metavar = fmap (fmap Data.Text.Lazy.pack) (parseString metavar)
+
 instance ParseField Data.Text.Lazy.Text where
-    parseField = fmap (fmap Data.Text.Lazy.pack) (parseString "TEXT")
+    parseField = parseTextLazy "TEXT"
+
+instance ParseField Data.ByteString.Lazy.ByteString where
+    parseField = fmap (fmap (Data.Text.Lazy.Encoding.encodeUtf8)) (parseTextLazy "UTF8-BYTESTRING")
 
 instance ParseField FilePath where
     parseField = fmap (fmap Filesystem.decodeString) (parseString "FILEPATH")
@@ -353,6 +361,7 @@ instance ParseFields Integer
 instance ParseFields Ordering
 instance ParseFields Void
 instance ParseFields Data.ByteString.ByteString
+instance ParseFields Data.ByteString.Lazy.ByteString
 instance ParseFields Data.Text.Text
 instance ParseFields Data.Text.Lazy.Text
 instance ParseFields FilePath
@@ -462,6 +471,9 @@ instance ParseRecord FilePath where
     parseRecord = fmap getOnly parseRecord
 
 instance ParseRecord Data.ByteString.ByteString where
+    parseRecord = fmap getOnly parseRecord
+
+instance ParseRecord Data.ByteString.Lazy.ByteString where
     parseRecord = fmap getOnly parseRecord
 
 instance ParseRecord Data.Time.Calendar.Day where

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -199,6 +199,7 @@ import qualified Data.Text.Lazy
 import qualified Data.Time.Calendar
 import qualified Data.Time.Format
 import qualified Data.Typeable
+import qualified Data.ByteString.Char8     as ByteString
 import qualified Filesystem.Path.CurrentOS as Filesystem
 import qualified Options.Applicative       as Options
 import qualified Options.Applicative.Types as Options
@@ -302,6 +303,9 @@ instance ParseField Data.Text.Lazy.Text where
 instance ParseField FilePath where
     parseField = fmap (fmap Filesystem.decodeString) (parseString "FILEPATH")
 
+instance ParseField ByteString.ByteString where
+    parseField = fmap (fmap ByteString.pack) (parseString "BYTESTRING")
+
 instance ParseField Data.Time.Calendar.Day where
     parseField m = do
         let metavar = "YYYY-MM-DD"
@@ -344,6 +348,7 @@ instance ParseFields Int
 instance ParseFields Integer
 instance ParseFields Ordering
 instance ParseFields Void
+instance ParseFields ByteString.ByteString
 instance ParseFields Data.Text.Text
 instance ParseFields Data.Text.Lazy.Text
 instance ParseFields FilePath
@@ -450,6 +455,9 @@ instance ParseRecord All where
     parseRecord = fmap getOnly parseRecord
 
 instance ParseRecord FilePath where
+    parseRecord = fmap getOnly parseRecord
+
+instance ParseRecord ByteString.ByteString where
     parseRecord = fmap getOnly parseRecord
 
 instance ParseRecord Data.Time.Calendar.Day where

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -195,11 +195,12 @@ import Prelude hiding (FilePath)
 import Options.Applicative (Parser, ReadM)
 
 import qualified Data.Text
+import qualified Data.Text.Encoding
 import qualified Data.Text.Lazy
 import qualified Data.Time.Calendar
 import qualified Data.Time.Format
 import qualified Data.Typeable
-import qualified Data.ByteString.Char8     as ByteString
+import qualified Data.ByteString
 import qualified Filesystem.Path.CurrentOS as Filesystem
 import qualified Options.Applicative       as Options
 import qualified Options.Applicative.Types as Options
@@ -294,17 +295,20 @@ parseString metavar m =
                    <> Options.long (Data.Text.unpack name)
             Options.option Options.str fs
 
+parseText :: String -> Maybe Text -> Parser Data.Text.Text
+parseText metavar = fmap (fmap Data.Text.pack) (parseString metavar)
+
 instance ParseField Data.Text.Text where
-    parseField = fmap (fmap Data.Text.pack) (parseString "TEXT")
+    parseField = parseText "TEXT"
+
+instance ParseField Data.ByteString.ByteString where
+    parseField = fmap (fmap (Data.Text.Encoding.encodeUtf8)) (parseText "UTF8-BYTESTRING")
 
 instance ParseField Data.Text.Lazy.Text where
     parseField = fmap (fmap Data.Text.Lazy.pack) (parseString "TEXT")
 
 instance ParseField FilePath where
     parseField = fmap (fmap Filesystem.decodeString) (parseString "FILEPATH")
-
-instance ParseField ByteString.ByteString where
-    parseField = fmap (fmap ByteString.pack) (parseString "BYTESTRING")
 
 instance ParseField Data.Time.Calendar.Day where
     parseField m = do
@@ -348,7 +352,7 @@ instance ParseFields Int
 instance ParseFields Integer
 instance ParseFields Ordering
 instance ParseFields Void
-instance ParseFields ByteString.ByteString
+instance ParseFields Data.ByteString.ByteString
 instance ParseFields Data.Text.Text
 instance ParseFields Data.Text.Lazy.Text
 instance ParseFields FilePath
@@ -457,7 +461,7 @@ instance ParseRecord All where
 instance ParseRecord FilePath where
     parseRecord = fmap getOnly parseRecord
 
-instance ParseRecord ByteString.ByteString where
+instance ParseRecord Data.ByteString.ByteString where
     parseRecord = fmap getOnly parseRecord
 
 instance ParseRecord Data.Time.Calendar.Day where

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -297,23 +297,17 @@ parseString metavar m =
                    <> Options.long (Data.Text.unpack name)
             Options.option Options.str fs
 
-parseText :: String -> Maybe Text -> Parser Data.Text.Text
-parseText metavar = fmap (fmap Data.Text.pack) (parseString metavar)
-
 instance ParseField Data.Text.Text where
-    parseField = parseText "TEXT"
+    parseField = fmap (fmap Data.Text.pack) (parseString "TEXT")
 
 instance ParseField Data.ByteString.ByteString where
-    parseField = fmap (fmap (Data.Text.Encoding.encodeUtf8)) (parseText "UTF8-BYTESTRING")
-
-parseTextLazy :: String -> Maybe Text -> Parser Data.Text.Lazy.Text
-parseTextLazy metavar = fmap (fmap Data.Text.Lazy.pack) (parseString metavar)
+    parseField = fmap (fmap Data.Text.Encoding.encodeUtf8) parseField
 
 instance ParseField Data.Text.Lazy.Text where
-    parseField = parseTextLazy "TEXT"
+    parseField = fmap (fmap Data.Text.Lazy.pack) (parseString "TEXT")
 
 instance ParseField Data.ByteString.Lazy.ByteString where
-    parseField = fmap (fmap (Data.Text.Lazy.Encoding.encodeUtf8)) (parseTextLazy "UTF8-BYTESTRING")
+    parseField = fmap (fmap Data.Text.Lazy.Encoding.encodeUtf8) parseField
 
 instance ParseField FilePath where
     parseField = fmap (fmap Filesystem.decodeString) (parseString "FILEPATH")


### PR DESCRIPTION
I tried to implement #7.
Please check if this is the desired behavior, as I don't have any experience with `ByteString`.
