### PR TITLE
Adds ParseFields/ParseRecord instances for NonEmpty

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -30,7 +30,9 @@ Library
         optparse-applicative >= 0.11.0  && < 0.14,
         time                 >= 1.5     && < 1.7 ,
         void                               < 0.8 ,
-        bytestring                         < 0.11
+        bytestring                         < 0.11,
+        semigroups           >= 0.18.1
+
     if impl(ghc < 7.8)
         Build-Depends:
             singletons       >= 0.10.0  && < 1.0 ,

--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -31,7 +31,7 @@ Library
         time                 >= 1.5     && < 1.7 ,
         void                               < 0.8 ,
         bytestring                         < 0.11,
-        semigroups           >= 0.18.1
+        semigroups           >= 0.5.0   && < 0.19
 
     if impl(ghc < 7.8)
         Build-Depends:

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -235,6 +235,7 @@ import Control.Applicative
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Char (toLower, toUpper)
 import Data.Monoid
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Proxy
 import Data.Text (Text)
 import Data.Typeable (Typeable)
@@ -476,6 +477,9 @@ instance (Num a, ParseField a) => ParseFields (Product a) where
 instance ParseField a => ParseFields [a] where
     parseFields = parseListOfField
 
+instance ParseField a => ParseFields (NonEmpty a) where
+    parseFields h m = (:|) <$> parseField h m <*> parseListOfField h m
+
 {-| Use this to annotate a field with a type-level string (i.e. a `Symbol`)
     representing the help description for that field:
 
@@ -587,6 +591,9 @@ instance (Num a, ParseField a) => ParseRecord (Product a) where
     parseRecord = fmap getOnly parseRecord
 
 instance ParseField a => ParseRecord [a] where
+    parseRecord = fmap getOnly parseRecord
+
+instance ParseField a => ParseRecord (NonEmpty a) where
     parseRecord = fmap getOnly parseRecord
 
 instance (ParseFields a, ParseFields b) => ParseRecord (a, b)


### PR DESCRIPTION
Adds appropriate instances to support non-empty parameter lists.

A record field such as `sheet :: NonEmpty Text`, becomes:

```
 --sheet TEXT [--sheet TEXT]
```

This does incur a dependency on `semigroups`, so not sure how you feel about that. Also the version bound on semigroups should probably be changed but I'll admit I don't know how the policy works. Should it be `< 0.19` ?
