### PR TITLE
Ability to automatically apply unHelpful to parsed fields

### DIFF
--- a/examples/unwrap-options.hs
+++ b/examples/unwrap-options.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+
+import Data.Coerce
+import Options.Generic
+
+data Options w = Options
+  { a :: w ::: Int <?> "Int option"
+  , b :: w ::: Bool <?> "Bool option"
+  , c :: w ::: String <?> "String option"
+  } deriving Generic
+
+instance ParseRecord (Options Wrapped)
+deriving instance Show (Options Unwrapped)
+
+main = do
+  opts <- unwrapRecord "unwrap-example"
+  print (opts :: Options Unwrapped)

--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -27,7 +27,7 @@ Library
         system-filepath      >= 0.3.1   && < 0.5 ,
         text                               < 1.3 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
-        optparse-applicative >= 0.11.0  && < 0.14,
+        optparse-applicative >= 0.12.0  && < 0.14,
         time                 >= 1.5     && < 1.7 ,
         void                               < 0.8 ,
         bytestring                         < 0.11,

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -800,14 +800,9 @@ getRecord
     => Text
     -- ^ Program description
     -> io a
-getRecord desc = liftIO (Options.customExecParser prefs info)
+getRecord desc = liftIO (Options.customExecParser defaultParserPrefs info)
   where
-    prefs = Options.defaultPrefs
-        { Options.prefMultiSuffix = "..."
-        }
-
     header = Options.header (Data.Text.unpack desc)
-
     info = Options.info parseRecord header
 
 {-| Pure version of `getRecord`
@@ -826,18 +821,13 @@ getRecordPure
     -- ^ Command-line arguments
     -> Maybe a
 getRecordPure args = do
-    let prefs = Options.ParserPrefs
-            { prefMultiSuffix     = "..."
-            , prefDisambiguate    = False
-            , prefShowHelpOnError = False
-            , prefBacktrack       = True
-            , prefColumns         = 80
-#if MIN_VERSION_optparse_applicative(0,13,0)
-            , prefShowHelpOnEmpty = False
-#else
-#endif
-            }
     let header = Options.header ""
     let info   = Options.info parseRecord header
     let args'  = map Data.Text.unpack args
-    Options.getParseResult (Options.execParserPure prefs info args')
+    Options.getParseResult (Options.execParserPure defaultParserPrefs info args')
+
+-- | @optparse-generic@'s flavor of options.
+defaultParserPrefs :: Options.ParserPrefs
+defaultParserPrefs = Options.defaultPrefs
+  { Options.prefMultiSuffix = "..."
+  }


### PR DESCRIPTION
By means of a small tweak to record definitions, the user is spared from explicitly applying `unHelpful` to their fields.