### PR TITLE
Add support for generating short flags for options.  Fixes #33

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -251,12 +251,8 @@
 -- > 
 -- > modifiers :: Modifiers
 -- > modifiers = defaultModifiers
--- >     { shortNameModifier = safeHead
+-- >     { shortNameModifier = firstLetter
 -- >     }
--- >
--- > safeHead :: String -> Maybe Char
--- > safeHead (c:_) = Just c
--- > safeHead  _    = Nothing
 -- >
 -- > instance ParseRecord Example where
 -- >     parseRecord = parseRecordWithModifiers modifiers
@@ -282,6 +278,7 @@ module Options.Generic (
     , parseRecordWithModifiers
     , defaultModifiers
     , lispCaseModifiers
+    , firstLetter
 
     -- * Help
     , type (<?>)(..)
@@ -755,6 +752,13 @@ lispCaseModifiers = Modifiers lispCase lispCase (\_ -> Nothing)
     lispCase = dropWhile (== '-') . (>>= lower) . dropWhile (== '_')
     lower c | isUpper c = ['-', toLower c]
             | otherwise = [c]
+
+{-| Use this for the `shortNameModifier` field of the `Modifiers` record if
+    you want to use the first letter of each option as the short name
+-}
+firstLetter :: String -> Maybe Char
+firstLetter (c:_) = Just c
+firstLetter  _    = Nothing
 
 class GenericParseRecord f where
     genericParseRecord :: Modifiers -> Parser (f p)

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -304,6 +304,7 @@ module Options.Generic (
 import Control.Applicative
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Char (isUpper, toLower, toUpper)
+import Data.Foldable (foldMap)
 import Data.Monoid
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Proxy


### PR DESCRIPTION
This adds a new `shortNameModifier` to the `Modifiers` record which is
used to optionally generate a short flag for labeled fields

This change also updates the documentation around how to use `Modifiers`