### PR TITLE
Allow modification of ParserInfo and ParserPrefs for top-level parser entrypoints

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -985,7 +985,7 @@ getWithHelp desc = do
 
 {-| Pure version of `getRecord`
 
-If you need to modify the glocal 'ParserInfo' or 'ParserPrefs', use
+If you need to modify the parser's 'ParserInfo' or 'ParserPrefs', use
 `getRecordPure'`.
 
 >>> :set -XOverloadedStrings
@@ -1006,7 +1006,8 @@ getRecordPure args = getRecordPure' args mempty mempty
 {-| Pure version of `getRecord'`
 
 Like `getRecord'`, this is a sibling of 'getRecordPure' and exposes
-the monoidal modifier structures to you.
+the monoidal modifier structures for 'ParserInfo' and 'ParserPrefs' to
+you.
 
 >>> :set -XOverloadedStrings
 >>> getRecordPure' ["1"] mempty mempty :: Maybe Int

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -1083,7 +1083,7 @@ unwrap = to . genericUnwrap . from
 -- | Marshal any value that implements 'ParseRecord' from the command line
 -- and unwrap its fields
 unwrapRecord
-    :: (MonadIO io, ParseRecord (f Wrapped), Unwrappable f)
+    :: (Functor io, MonadIO io, ParseRecord (f Wrapped), Unwrappable f)
     => Text
     -> io (f Unwrapped)
 unwrapRecord = fmap unwrap . getRecord

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -954,7 +954,7 @@ getRecord desc = getRecordWith header mempty
 
 -- | Marshal any value that implements `ParseRecord` from the command line
 --
--- This is the lower-level sibling of 'getRecordWith and lets you modify
+-- This is the lower-level sibling of 'getRecord and lets you modify
 -- the 'ParserInfo' and 'ParserPrefs' records.
 getRecordWith
     :: (MonadIO io, ParseRecord a)

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -1006,7 +1006,7 @@ getRecordPure args = getRecordPureWith args mempty mempty
 
 {-| Pure version of `getRecordWith`
 
-Like `getRecordWith`, this is a sibling of 'getRecordPureWith and
+Like `getRecordWith`, this is a sibling of 'getRecordPure and
 exposes the monoidal modifier structures for 'ParserInfo' and
 'ParserPrefs' to you.
 

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -1055,7 +1055,7 @@ unwrap = to . genericUnwrap . from
 -- | Marshal any value that implements 'ParseRecord' from the command line
 -- and unwrap its fields
 unwrapRecord
-    :: (Functor io, MonadIO io, ParseRecord (f Wrapped), Unwrappable f)
+    :: (MonadIO io, ParseRecord (f Wrapped), Unwrappable f)
     => Text
     -> io (f Unwrapped)
 unwrapRecord = fmap unwrap . getRecord

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -963,7 +963,7 @@ getRecordWith
     -> Options.PrefsMod
     -- ^ 'ParserPrefs' modifiers
     -> io a
-getRecordWith infoMods prefMods = liftIO (Options.customExecParser prefs info)
+getRecordWith infoMods prefsMods = liftIO (Options.customExecParser prefs info)
   where
     prefs  = Options.prefs (defaultParserPrefs <> prefsMods)
     info   = Options.info parseRecord infoMods

--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -307,6 +307,7 @@ import Data.Proxy
 import Data.Text (Text)
 import Data.Typeable (Typeable)
 import Data.Void (Void)
+import Data.Foldable (foldMap)
 import Filesystem.Path (FilePath)
 import GHC.Generics
 import Prelude hiding (FilePath)


### PR DESCRIPTION
This change fixes a few minor compiler warnings and adds two functions:
- `getRecord'` and
- `getRecordPure'`

Both of these functions handle the construction of the parser entrypoint and expose the `InfoMod` and `PrefsMod` monoidal configuration modifier structures. Both of these functions are reused by their non-prime siblings.

The `defaultParserPrefs` was switched to returning a `PrefsMod` so that it can be composed with the other prefs modifiers nicely.

The motivation for this change came because I had to crib `getRecord` verbatim so that I could add the `noIntersperse` modifier to the `ParserInfo` of my parser and there was no simple mechanism to do this without cribbing. The prime versions of the two parser entrypoint functions are backwards compatible and maintain the defaults already established by the library but expose the two top-level configuration modifier structures so that one could drop down to those if something more custom is needed.