### PR TITLE
Relaxing the upper bound of optparse-applicative to allow for the 0.14.* release

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -27,7 +27,7 @@ Library
         system-filepath      >= 0.3.1   && < 0.5 ,
         text                               < 1.3 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
-        optparse-applicative >= 0.12.0  && < 0.14,
+        optparse-applicative >= 0.12.0  && < 0.15,
         time                 >= 1.5     && < 1.7 ,
         void                               < 0.8 ,
         bytestring                         < 0.11,


### PR DESCRIPTION
This change relaxes the upper bound of the version constraint for `optparse-applicative` so that `optparse-generic` will build with the latest release of `optparse-applicative`.

I tested the build by (temporarily) adding an override derivation for optparse-applicative to the `release.nix` and issuing `nix-build -A optparse-generic release.nix` to ensure that this library compiles with the latest version of the dependency. It does so without error.

~I've not functionally tested this yet (I'm doing that today) and will do so before recommending that this PR be merged.~