### PR TITLE
Relax time bound in preparation for GHC 8.2

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -28,7 +28,7 @@ Library
         text                               < 1.3 ,
         transformers         >= 0.2.0.0 && < 0.6 ,
         optparse-applicative >= 0.12.0  && < 0.15,
-        time                 >= 1.5     && < 1.7 ,
+        time                 >= 1.5     && < 1.9 ,
         void                               < 0.8 ,
         bytestring                         < 0.11,
         semigroups           >= 0.5.0   && < 0.19


### PR DESCRIPTION
GHC 8.2 is very likely to ship with time-1.8.0.1.

See also:
https://ghc.haskell.org/trac/ghc/wiki/Commentary/Libraries/VersionHistory

FWIW the library builds with GHC 8.2 after that.