### PR TITLE
Export getRecordWith and getRecordPureWith

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -264,8 +264,10 @@
 module Options.Generic (
     -- * Parsers
       getRecord
+    , getRecordWith
     , getWithHelp
     , getRecordPure
+    , getRecordPureWith
     , unwrapRecord
     , unwrapWithHelp
     , unwrapRecordPure


### PR DESCRIPTION
Apparently I forgot to export these functions in https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/pull/38...