### PR TITLE
Bump time bounds

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -30,7 +30,7 @@ Library
         transformers         >= 0.2.0.0  && < 0.6 ,
         Only                                < 0.2 ,
         optparse-applicative >= 0.14.0.0 && < 0.16,
-        time                 >= 1.5      && < 1.9 ,
+        time                 >= 1.5      && < 1.10,
         void                                < 0.8 ,
         bytestring                          < 0.11,
         semigroups           >= 0.5.0    && < 0.20


### PR DESCRIPTION
This allows building with GHC 8.8.1

(I guess there should be a hackage revision as well)