### PR TITLE
Export `GenericParseRecord`

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -281,6 +281,7 @@ module Options.Generic (
     , defaultModifiers
     , lispCaseModifiers
     , firstLetter
+    , GenericParseRecord(..)
 
     -- * Help
     , type (<?>)(..)


### PR DESCRIPTION
Fixes https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/issues/57