### PR TITLE
Fix a broken haddock comment block

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -119,7 +119,7 @@
 --
 -- > $ stack runghc Example.hs -- --foo 1 --bar 2.5
 -- > Example {foo = 1, bar = 2.5}
-
+--
 -- You can also add default values to each `Read`able field, like this:
 --
 -- > {-# LANGUAGE DataKinds         #-}


### PR DESCRIPTION
The big comment block at the beginning of the file were split into two due to a missing `--`. This resulted in `cabal haddock` failure:

```
Build profile: -w ghc-8.10.1 -O1
In order, the following will be built (use -v for more details):
 - optparse-generic-1.4.0 (lib) (first run)
Preprocessing library for optparse-generic-1.4.0..
Running Haddock on library for optparse-generic-1.4.0..
Warning: The documentation for the following packages are not installed. No
links will be generated to these packages: Only-0.1, colour-2.3.5,
ansi-terminal-0.10.3, ansi-wl-pprint-0.6.9, optparse-applicative-0.15.1.0,
semigroups-0.19.1, system-filepath-0.4.14, transformers-compat-0.6.5,
void-0.7.3

src/Options/Generic.hs:239:1: error:
    parse error on input ‘-- * recursive types:’
    |
239 | -- * recursive types:
    | ^^^^^^^^^^^^^^^^^^^^^
cabal: Failed to build documentation for optparse-generic-1.4.0.
```

This PR fixes it.