### PR TITLE
Export `readIntegralBounded`

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -299,6 +299,7 @@ module Options.Generic (
     , ParseField(..)
     , Only(..)
     , getOnly
+    , readIntegralBounded
     , Modifiers(..)
     , parseRecordWithModifiers
     , defaultModifiers


### PR DESCRIPTION
Export utility `readIntegralBounded` to be used with derivative integral types such as `Port` numbers having same range as `Word16` except that 0 is not allowed.

```haskell
{-# LANGUAGE DerivingStrategies #-}
{-# LANGUAGE GeneralizedNewtypeDeriving #-}

newtype Port = Port Word16
    deriving newtype (Enum, Eq, Integral, Num, Ord, Read, Real, Show)

instance Bounded Port where
    minBound = 1
    maxBound = 0xFFFF

instance ParseField Port where readField = readIntegralBounded
instance ParseFields Port
instance ParseRecord Port where parseRecord = fmap getOnly parseRecord
```