### PR TITLE
readIntegralBounded: use metavar in error message

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -452,7 +452,7 @@ instance ParseField Ordering
 instance ParseField ()
 instance ParseField Void
 
-readIntegralBounded :: forall a. (Integral a, Bounded a, Typeable a) => ReadM a
+readIntegralBounded :: forall a. (Integral a, Bounded a, Typeable a, ParseField a) => ReadM a
 readIntegralBounded =
     auto >>= f
     where
@@ -461,7 +461,7 @@ readIntegralBounded =
             | otherwise = pure $ fromInteger i
         lower = toInteger (minBound :: a)
         upper = toInteger (maxBound :: a)
-        msg = map toUpper (show (Data.Typeable.typeOf (undefined :: a))) <>
+        msg = metavar (Proxy :: Proxy a) <>
               " must be within the range [" <>
               show lower <> " .. " <> show upper <> "]"
 


### PR DESCRIPTION
Given the following snippet:
```haskell
{-# LANGUAGE DataKinds #-}
{-# LANGUAGE DeriveGeneric #-}
{-# LANGUAGE DerivingStrategies #-}
{-# LANGUAGE GeneralizedNewtypeDeriving #-}
{-# LANGUAGE OverloadedStrings #-}
{-# LANGUAGE TypeOperators #-}

newtype NumWorkers = NumWorkers Word8
    deriving newtype (Enum, Eq, Integral, Num, Ord, Read, Real, Show)

instance Bounded NumWorkers where
    minBound = 1
    maxBound = 0xFF

instance ParseField NumWorkers where
    readField = readIntegralBounded
    metavar _ = "CAT"

instance ParseFields NumWorkers
instance ParseRecord NumWorkers where parseRecord = fmap getOnly parseRecord

data Options w = Options
    { workers :: w ::: NumWorkers <?> "Number of workers (>0)" 
    } deriving (Generic)

...
```

The help message would look like the following; the custom `metavar` is correctly shown:
```text
Usage: example [-w|--workers CAT]

Available options:
  -w,--workers CAT         Number of workers (>0)
```
Running this with `--workers 0` will expectedly produce an error message.
Unfortunately it uses the wrong metavar string:
`option --workers: NUMWORKERS must be within the range [1 .. 255]`

--

This PR updates the message to use the correct `metavar` string.
ie: `option --workers: CAT must be within the range [1 .. 255]`

When `metavar` is not provided by an instance, the default would be used which matches the previous behavior.
