### PR TITLE
Add type-set default value to help text

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -420,6 +420,7 @@ class ParseField a where
                        <> foldMap (Options.help . Data.Text.unpack) h
                        <> foldMap Options.short c
                        <> foldMap Options.value (d >>= Text.Read.readMaybe)
+                       <> foldMap (Options.showDefaultWith . const) d
                 Options.option   readField fs
 
     {-| The only reason for this method is to provide a special case for
@@ -520,7 +521,7 @@ parseHelpfulString metavar h m c d =
                    <> Options.long (Data.Text.unpack name)
                    <> foldMap (Options.help . Data.Text.unpack) h
                    <> foldMap Options.short c
-                   <> foldMap Options.value d
+                   <> foldMap ((Options.showDefault <>) . Options.value) d
             Options.option Options.str fs
 
 instance ParseField Data.Text.Text where


### PR DESCRIPTION
As mentioned in https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/pull/61, it would be nice if default values showed up in help messages.  This PR implements such a change that I'm using personally and thought might be desired upstream.

This is a small change so that a field with `<!> "defaultValue"` will show ` (Default: defaultValue)` in the help string.  I opted to put this in the `parseFields` definition, which means that the order of field decorators now matters: that is, if one writes `... <!> "1" <?> "Field help"`, then the help text will read `Field help (Default: 1)`, but if the order is `... <?> "Field help" <!> "1"`, then the help text will read `Field help`.  This is by design so that the behavior could be overridden if desired.