### PR TITLE
Build executable for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work
 dist-newstyle
+.DS_Store

--- a/examples/unwrap-options.hs
+++ b/examples/unwrap-options.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
 
-import Data.Coerce
 import Options.Generic
 
 data Options w = Options
@@ -17,6 +16,7 @@ data Options w = Options
 instance ParseRecord (Options Wrapped)
 deriving instance Show (Options Unwrapped)
 
+main :: IO ()
 main = do
   opts <- unwrapRecord "unwrap-example"
   print (opts :: Options Unwrapped)

--- a/examples/unwrap-with-help.hs
+++ b/examples/unwrap-with-help.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
 
-import Data.Coerce
 import Options.Generic
 
 data Options w = Options
@@ -17,6 +16,7 @@ data Options w = Options
 instance ParseRecord (Options Wrapped)
 deriving instance Show (Options Unwrapped)
 
+main :: IO ()
 main = do
   (opts, help) <- unwrapWithHelp "unwrap-example"
   if (a opts) `rem` 10 == 0

--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -47,3 +47,21 @@ Library
     Exposed-Modules: Options.Generic
     GHC-Options: -Wall
     Default-Language: Haskell2010
+
+executable optparse-generic-example-unwrap-options
+  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs: examples
+  main-is: unwrap-options.hs
+  build-depends:
+    base   >= 4.7 && <5,
+    optparse-generic
+
+executable optparse-generic-example-unwrap-with-help
+  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs: examples
+  main-is: unwrap-with-help.hs
+  build-depends:
+    base   >= 4.7 && <5,
+    optparse-generic


### PR DESCRIPTION
My main goal was to make sure examples still compile/run whenever code changes and be able to play with various usage.

I tried to migrate to test-suites but turns out those examples expect arguments from CLI to run hence I'm thinking to make them as executable, which is good enough to meet the original goal.

Curious what's your thoughts/suggestions? @Gabriella439 