### PR TITLE
Derive `Data` for `Unwrapped`

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -1227,6 +1227,7 @@ data Wrapped
 
 -- | Flag to unwrap fields annotated using '(<?>)'
 data Unwrapped
+    deriving (Data)
 
 -- | Constraint for types whose fields can be unwrapped
 type Unwrappable f = (Generic (f Wrapped), Generic (f Unwrapped), GenericUnwrappable (Rep (f Wrapped)) (Rep (f Unwrapped)))


### PR DESCRIPTION
This appears to be necessary for `Unwrapped` types to derive `Data`.  In other words, if you try to do something like:

```haskell
deriving stock instance Data (Foo Unwrapped)
```

… it will complain about a missing `Data` instance for `Unwrapped`