### PR TITLE
Fix metavars for some `time` types

### DIFF
--- a/src/Options/Generic.hs
+++ b/src/Options/Generic.hs
@@ -580,12 +580,12 @@ instance ParseField Day where
     readField = readISO8601Field
 
 instance ParseField UTCTime where
-    metavar _ = "yyyy-mm-ddThh:mm:ss"
+    metavar _ = "yyyy-mm-ddThh:mm:ss[.sss]Z"
 
     readField = readISO8601Field
 
 instance ParseField CalendarDiffTime where
-    metavar _ = "PyYmMdDThHmMs"
+    metavar _ = "PyYmMdDThHmMs[.sss]S"
 
     readField = readISO8601Field
 


### PR DESCRIPTION
… to exactly match the documentation