### PR TITLE
optparse-generic.cabal: Raise optparse-applicative bound

### DIFF
--- a/optparse-generic.cabal
+++ b/optparse-generic.cabal
@@ -29,12 +29,12 @@ Library
         transformers         >= 0.2.0.0  && < 0.7 ,
         transformers-compat  >= 0.3      && < 0.8 ,
         Only                                < 0.2 ,
-        optparse-applicative >= 0.16.0.0 && < 0.19,
+        optparse-applicative >= 0.16.0.0 && < 0.20,
         time                 >= 1.5      && < 1.15,
         void                                < 0.8 ,
         bytestring                          < 0.13,
         filepath                            < 1.6
-    
+
     if impl(ghc < 8.0)
         Build-Depends:
             semigroups           >= 0.5.0    && < 0.20


### PR DESCRIPTION
Tested with `cabal build --constraint 'optparse-applicative ^>=0.19'`. Can we please have a Hackage metadata revision?